### PR TITLE
allow promotion.timing_methods to call home/away

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,8 @@ gem 'bootsnap', require: false
 gem 'nokogiri', '>= 1.16.5'
 gem 'rack', '~> 2.2.8'
 gem 'rdoc', '>= 6.6.3.1'
-gem 'rexml', '>= 3.2.8'
+gem 'rexml', '>= 3.3.2'
+# Security pinning
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -258,8 +258,8 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rexml (3.2.8)
-      strscan (>= 3.0.9)
+    rexml (3.3.2)
+      strscan
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -388,7 +388,7 @@ DEPENDENCIES
   rdoc (>= 6.6.3.1)
   redis (>= 4.0.1)
   rest-client
-  rexml (>= 3.2.8)
+  rexml (>= 3.3.2)
   rspec
   rspec-rails
   rubocop

--- a/app/services/base_client.rb
+++ b/app/services/base_client.rb
@@ -22,14 +22,7 @@ module BaseClient
 
   private
 
-  def playing_today_at
-    Time.use_zone(@args[:timezone]) do
-      schedule_cache.find do |game|
-        game.team_abbrev == @args[:short_name] && game.utc_start_time.in_time_zone(@args[:timezone]).today?
-      end&.utc_start_time
-    end
-  end
-
+  ### results_cache dependents
   def scored_in?
     return false unless played? && results_cache[@args[:short_name]].try(:goals).present?
 
@@ -69,15 +62,28 @@ module BaseClient
     opponent.goals.empty?
   end
 
+  def won? = played? && results_cache[@args[:short_name]].try(:won?) == true
+
   def goal_count_equal_or_above?
     return false unless played?
 
     results_cache[@args[:short_name]].goals.size >= @args[:goals_count]
   end
 
-  def home? = played? && results_cache[@args[:short_name]].try(:away?) == false
+  def was_home? = played? && results_cache[@args[:short_name]].try(:away?) == false
+  def was_away? = played? && results_cache[@args[:short_name]].try(:away?) == true
+  ### results_cache dependents
 
-  def away? = played? && results_cache[@args[:short_name]].try(:away?)
+  ### schedule_cache dependents
+  def playing_today_at
+    Time.use_zone(@args[:timezone]) do
+      schedule_cache.find do |game|
+        game.team_abbrev == @args[:short_name] && game.utc_start_time.in_time_zone(@args[:timezone]).today?
+      end&.utc_start_time
+    end
+  end
 
-  def won? = played? && results_cache[@args[:short_name]].try(:won?) == true
+  def future_home_game? = schedule_cache.find { |game| game.team_abbrev == @args[:short_name] }.try(:away?) == false
+  def future_away_game? = schedule_cache.find { |game| game.team_abbrev == @args[:short_name] }.try(:away?) == true
+  ### schedule_cache dependents
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -29,9 +29,9 @@ Promotion.create!(
   redemption_limiter: 'monthly',
   redemption_count: 0,
   hours_valid: 48,
-  timing_methods: ['playing_at'],
+  timing_methods: ['playing_today_at'],
   timing_parameters: { minutes_before: 60 },
-  api_methods: %w[home? perfect_defence?],
+  api_methods: %w[was_home? perfect_defence?],
   api_parameters: {},
   team: Team.find_by(short_name: 'clb', region: 'oh', league: League.find_by(short_name: 'mls'))
 )
@@ -61,7 +61,7 @@ Promotion.create!(
   hours_valid: 24,
   timing_methods: [],
   timing_parameters: {},
-  api_methods: %w[home? goal_count_equal_or_above?],
+  api_methods: %w[was_home? goal_count_equal_or_above?],
   api_parameters: { goals_count: 1 },
   team: Team.find_by(short_name: 'clb', region: 'oh', league: League.find_by(short_name: 'mls'))
 )

--- a/spec/factories/promotions.rb
+++ b/spec/factories/promotions.rb
@@ -17,26 +17,6 @@ FactoryBot.define do
 
     team
 
-    trait :cbj_moo_moo_carwash do
-      company { 'Moo Moo Express Car Wash' }
-      promo_type { 'free_gifts' }
-      name { 'Moo Moo Express Car Wash 3rd Period Goal' }
-      promo_code { nil }
-      source_url { 'https://www.nhl.com/bluejackets/fans/gameday-central' }
-      api_methods { %w[scored_in?] }
-      api_parameters { { period: 3 } }
-      timing_methods { %w[playing_at] }
-      timing_parameters { { minutes_before: 60 } }
-      team { association :team, short_name: 'cbj', region: 'ohio', league: create(:league, short_name: 'nhl') }
-      # requirements do
-      #   [
-      #     'sign up on gameday', 'one hour before the start of the game',
-      #     'or till end of game', 'sign up here: https://moomoocarwash.com/cbj/',
-      #     'enter cellphone number'
-      #   ]
-      # end
-    end
-
     trait :with_league_team_and_users do
       transient do
         league_abbr { 'mls' }

--- a/spec/jobs/notify/email/time_sensitive_notification_job_spec.rb
+++ b/spec/jobs/notify/email/time_sensitive_notification_job_spec.rb
@@ -3,30 +3,56 @@
 require 'rails_helper'
 
 RSpec.describe Notify::Email::TimeSensitiveNotificationJob do
-  let!(:promotion) { create(:promotion, :cbj_moo_moo_carwash) }
-  let(:user) { create(:user, :with_contact_methods, region: 'ohio', timezone:) }
-  let(:client) { Nhl::Client.new(args: { timezone:, short_name: promotion.team.short_name }) }
+  let!(:promotion) { create(:promotion, :with_league_team_and_users, team_abbr:, league_abbr: 'nhl', timing_methods:) }
+  let(:timing_methods) { ['playing_today_at'] }
+  let(:user) { promotion.users.first }
+  let(:client) { Nhl::Client.new(args: { timezone:, short_name: team_abbr }) }
+  let(:team_abbr) { 'cbj' }
   let(:timezone) { 'America/New_York' }
   let(:freeze_time) { Time.at(0) }
   let(:utc_start_time) { freeze_time.in(1.hour) }
   let(:schedule_cache) do
     [
-      BaseClient::TodayGame.new(away?: true, team_abbrev: 'cbj', utc_start_time:),
-      BaseClient::TodayGame.new(away?: false, team_abbrev: 'arz', utc_start_time:)
+      BaseClient::TodayGame.new(away?: false, team_abbrev: 'cbj', utc_start_time:),
+      BaseClient::TodayGame.new(away?: true, team_abbrev: 'arz', utc_start_time:)
     ]
   end
 
   before do
+    Timecop.freeze(freeze_time)
     allow(Nhl::Client).to receive(:new).and_return(client)
     allow(client).to receive(:schedule_cache).and_return(schedule_cache)
   end
 
+  after do
+    Timecop.return
+  end
+
   describe '#perform' do
     it 'enqueues the email' do
-      Timecop.freeze(freeze_time) do
+      expect { described_class.new.perform }.to have_enqueued_mail(TimeSensitiveMailer, :notify)
+        .with(params: { user:, promotion: }, args: [])
+        .on_queue(:default).at(1.hour.from_now).exactly(:once)
+    end
+
+    context 'when there are location requirements for the promotion' do
+      let(:timing_methods) { %w[playing_today_at future_home_game?] }
+
+      it 'enqueues the email' do
         expect { described_class.new.perform }.to have_enqueued_mail(TimeSensitiveMailer, :notify)
           .with(params: { user:, promotion: }, args: [])
           .on_queue(:default).at(1.hour.from_now).exactly(:once)
+      end
+
+      context 'when the it is an away game expectation' do
+        let(:timing_methods) { %w[playing_today_at future_away_game?] }
+        let(:team_abbr) { 'arz' }
+
+        it 'enqueues the email' do
+          expect { described_class.new.perform }.to have_enqueued_mail(TimeSensitiveMailer, :notify)
+            .with(params: { user:, promotion: }, args: [])
+            .on_queue(:default).at(1.hour.from_now).exactly(:once)
+        end
       end
     end
   end

--- a/spec/models/promotion_spec.rb
+++ b/spec/models/promotion_spec.rb
@@ -27,8 +27,18 @@ RSpec.describe Promotion do
   describe '#evaluate' do
     subject(:evaluation) { promotion.evaluate(timezone:) }
 
-    let(:promotion) { create(:promotion, :cbj_moo_moo_carwash, api_methods:) }
+    let(:promotion) do
+      create(
+        :promotion,
+        :with_league_team_and_users,
+        team_abbr: 'cbj',
+        league_abbr: 'nhl',
+        api_methods:,
+        api_parameters:
+      )
+    end
     let(:api_methods) { ['scored_in?'] }
+    let(:api_parameters) { { period: 3 } }
     let(:yesterday_games) do
       {
         'cbj' => BaseClient::GameResult.new(

--- a/spec/services/nhl_spec.rb
+++ b/spec/services/nhl_spec.rb
@@ -133,8 +133,8 @@ RSpec.describe Nhl::Client do
       end
     end
 
-    describe '#home?' do
-      let(:method) { 'home?' }
+    describe '#was_home?' do
+      let(:method) { 'was_home?' }
 
       it { is_expected.to be true }
 
@@ -145,8 +145,8 @@ RSpec.describe Nhl::Client do
       end
     end
 
-    describe '#away?' do
-      let(:method) { 'away?' }
+    describe '#was_away?' do
+      let(:method) { 'was_away?' }
 
       it { is_expected.to be false }
 


### PR DESCRIPTION
updated some old calls to `played_at` and making `home?`/`away?` available to `promotion.timing_methods` so we don't notify users about a potential promotion when the team is actually away/home which makes the promotion not available.