### PR TITLE
change notification time to respect user timezones

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,9 +16,9 @@ gem 'jbuilder'
 gem 'pg'
 gem 'pry'
 gem 'puma', '>= 5.0'
-gem 'rails', '7.1.3.4' # set for bundler-audit
 gem 'redis', '>= 4.0.1'
 gem 'rest-client'
+gem 'rexml'
 gem 'rspec'
 gem 'rspec-rails'
 gem 'rubocop'
@@ -42,8 +42,8 @@ gem 'bootsnap', require: false
 # Security pinning
 gem 'nokogiri', '>= 1.16.5'
 gem 'rack', '~> 2.2.8'
+gem 'rails', '7.1.3.4'
 gem 'rdoc', '>= 6.6.3.1'
-gem 'rexml', '>= 3.3.2'
 # Security pinning
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -258,7 +258,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rexml (3.3.2)
+    rexml (3.3.4)
       strscan
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
@@ -388,7 +388,7 @@ DEPENDENCIES
   rdoc (>= 6.6.3.1)
   redis (>= 4.0.1)
   rest-client
-  rexml (>= 3.3.2)
+  rexml
   rspec
   rspec-rails
   rubocop

--- a/good_job_cron.yml
+++ b/good_job_cron.yml
@@ -1,5 +1,5 @@
 notify_actionable_promotions:
-  cron: 0 9 * * * # or 5 am ET
+  cron: 0 * * * *
   class: NotifyActionablePromotionJob
 time_sensitive_notifications:
   cron: 0 9 * * * # or 5 am ET

--- a/spec/jobs/notify_actionable_promotion_job_spec.rb
+++ b/spec/jobs/notify_actionable_promotion_job_spec.rb
@@ -3,9 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe NotifyActionablePromotionJob do
-  let(:freeze_time) { Time.at(0) }
   let(:promotions) { [create(:promotion, :with_league_team_and_users, team_abbr: 'clb')] }
   let(:user) { promotions.first.users.first }
+  let(:freeze_time) { Time.current.in_time_zone(user.timezone).change(time_adjustments) }
+  let(:time_adjustments) { { hour: 5 } }
   let(:client) { Mls::Client.new(args: { timezone: user.timezone, short_name: promotions.first.team.short_name }) }
   let(:jam_goals) { [BaseClient::Goal.new(period: 3, time: '07:25')] }
   let(:yesterday_start) { Time.current.yesterday }
@@ -40,10 +41,26 @@ RSpec.describe NotifyActionablePromotionJob do
 
   describe '#perform' do
     it 'enqueues the email with all the actionable promotions' do
-      Timecop.freeze(freeze_time) do
+      expect { described_class.new.perform }.to have_enqueued_mail(ActionablePromotionMailer, :notify)
+        .with(params: { user:, promotions: }, args: []).on_queue(:default)
+        .at(Time.use_zone(user.timezone) { Time.current.at_beginning_of_day + 6.hours }).exactly(:once)
+    end
+
+    context 'when the job is kicked off a few minutes late' do
+      let(:time_adjustments) { { hour: 5, minutes: 3 } }
+
+      it 'notifies the user at 6am' do
         expect { described_class.new.perform }.to have_enqueued_mail(ActionablePromotionMailer, :notify)
           .with(params: { user:, promotions: }, args: []).on_queue(:default)
           .at(Time.use_zone(user.timezone) { Time.current.at_beginning_of_day + 6.hours }).exactly(:once)
+      end
+    end
+
+    context 'when the hour too early' do
+      let(:time_adjustments) { { hour: 2 } }
+
+      it 'does not notify the users yet' do
+        expect { described_class.new.perform }.not_to have_enqueued_mail(ActionablePromotionMailer, :notify)
       end
     end
   end


### PR DESCRIPTION
previously notifications were just going out at 6am ET. anyways, that doesn't always work for every user for their commute or whatever. therefore it makes sense to send out notification emails at 6am respecting their timezone.