### PR TITLE
ensure that bin/jobs starts

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -35,3 +35,5 @@ pidfile ENV.fetch('PIDFILE', 'tmp/pids/server.pid')
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart
+# https://github.com/rails/solid_queue?tab=readme-ov-file#puma-plugin
+plugin :solid_queue

--- a/render.yaml
+++ b/render.yaml
@@ -15,8 +15,7 @@ services:
     runtime: ruby
     plan: free
     buildCommand: "./bin/render-build.sh"
-    # preDeployCommand: "bundle exec rails db:migrate" # preDeployCommand only available on paid instance types
-    startCommand: "bin/dev"
+    startCommand: "./bin/jobs; ./bin/rails server -p 3000 -b 0.0.0.0"
     envVars:
       - key: DATABASE_URL
         fromDatabase:


### PR DESCRIPTION
`bin/jobs` wasn't magically being run, needed to have a puma process begun in order for emails to actually be sent.