### PR TITLE
updated clean_up_old_games and updated mls fetcher

### DIFF
--- a/app/jobs/clean_up_old_games.rb
+++ b/app/jobs/clean_up_old_games.rb
@@ -3,9 +3,9 @@
 class CleanUpOldGames < ApplicationJob
   queue_as :default
 
+  # if there are promotions that last longer than a week after a game, it may be worth re-visiting
+  # how we clean up older games
   def perform
-    Game.where(finalized: true).map do |game|
-      game.destroy! if (game.utc_start_time + 1.week) < Time.current
-    end
+    Game.where('utc_start_time::date <= ?', 1.weeks.ago).each(&:destroy!)
   end
 end

--- a/app/services/interactor/mls.rb
+++ b/app/services/interactor/mls.rb
@@ -68,8 +68,13 @@ module Interactor
       end
 
       def week_ago_week_from_now_data
-        resp = RestClient.get(game_schedule_url(7.day.ago.strftime('%Y-%m-%d'), 7.day.from_now.strftime('%Y-%m-%d')))
-        JSON.parse(resp)['schedule']
+        # the requests return errors if there are no games found within the range borking this job in odd situations
+        # can fix this perhaps by rescuing from the bad status or w/e rest client error is raised
+        # even though they improved their API i fear that they are limiting return data...
+        today = Time.now.strftime('%Y-%m-%d')
+        [[7.day.ago.strftime('%Y-%m-%d'), today], [today, 7.day.from_now.strftime('%Y-%m-%d')]].map do |set|
+          JSON.parse(RestClient.get(game_schedule_url(*set)))['schedule']
+        end.flatten.uniq
       end
 
       def game_schedule_url(beg, fin)


### PR DESCRIPTION
in the past the mls store_jobs action failed with 4XX status codes which caused a failure, i 'fixed' this but i basically reverted this in this PR. should figured out a long term solution before the season is over.

also games that are obviously over should be deleted.