### PR TITLE
actually listened to Lint/SharedMutableDefault cop and it fixes it

### DIFF
--- a/app/jobs/notify/actionable_promotion_job.rb
+++ b/app/jobs/notify/actionable_promotion_job.rb
@@ -24,13 +24,17 @@ module Notify
     end
 
     def gather_users_and_promotions
-      in_season_promotions.each.with_object(Hash.new([])) do |promotion, hsh| # rubocop:disable Lint/SharedMutableDefault
-        users = promotion.users
-        timezones = timezones_to_evaluate(users:)
-        users.where(timezone: timezones).each do |user|
+      in_season_promotions.each.with_object(Hash.new { |h, k| h[k] = [] }) do |promotion, hsh|
+        users_for(promotion:).each do |user|
           hsh[user.id] = hsh[user.id].push(promotion) if promotion.evaluate_most_recent_game
         end
       end
+    end
+
+    def users_for(promotion:)
+      users = promotion.users
+      timezone = timezones_to_evaluate(users:)
+      users.where(timezone:)
     end
 
     def in_season_promotions


### PR DESCRIPTION
emails were rending multiple of the same promotions in the rendered email template which was dumb. actually looking into the cop https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/SharedMutableDefault the good not bad (what i was previously doing) seemed to fix stuffs. will merge in once emails look good!